### PR TITLE
Add new commitment hook

### DIFF
--- a/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
@@ -123,7 +123,7 @@ use sp_runtime::{
 	DigestItem, Saturating,
 };
 use sp_std::prelude::*;
-pub use types::{CommittedMessage, ProcessMessageOriginOf};
+pub use types::{CommittedMessage, ProcessMessageOriginOf, OnNewCommitment};
 pub use weights::WeightInfo;
 
 pub use pallet::*;
@@ -170,6 +170,8 @@ pub mod pallet {
 		type Channels: Contains<ChannelId>;
 
 		type PricingParameters: Get<PricingParameters<Self::Balance>>;
+
+		type OnNewCommitment: OnNewCommitment;
 
 		/// Convert a weight value into a deductible fee based.
 		type WeightToFee: WeightToFee<Balance = Self::Balance>;
@@ -291,6 +293,8 @@ pub mod pallet {
 
 			// Create merkle root of messages
 			let root = merkle_root::<<T as Config>::Hashing, _>(MessageLeaves::<T>::stream_iter());
+
+			T::OnNewCommitment::on_new_commitment(root);
 
 			let digest_item: DigestItem = CustomDigestItem::Snowbridge(root).into();
 

--- a/bridges/snowbridge/pallets/outbound-queue/src/mock.rs
+++ b/bridges/snowbridge/pallets/outbound-queue/src/mock.rs
@@ -92,6 +92,7 @@ impl crate::Config for Test {
 	type PricingParameters = Parameters;
 	type Channels = Everything;
 	type WeightToFee = IdentityFee<u128>;
+	type OnNewCommitment = ();
 	type WeightInfo = ();
 }
 

--- a/bridges/snowbridge/pallets/outbound-queue/src/types.rs
+++ b/bridges/snowbridge/pallets/outbound-queue/src/types.rs
@@ -57,3 +57,13 @@ impl From<CommittedMessage> for Token {
 		])
 	}
 }
+
+
+/// Hook that will be called when new message commitment is constructed
+pub trait OnNewCommitment {
+	fn on_new_commitment(commitment: H256);
+}
+
+impl OnNewCommitment for () {
+	fn on_new_commitment(_commitment: H256) {}
+}

--- a/bridges/snowbridge/pallets/system/src/mock.rs
+++ b/bridges/snowbridge/pallets/system/src/mock.rs
@@ -160,6 +160,7 @@ impl snowbridge_pallet_outbound_queue::Config for Test {
 	type PricingParameters = EthereumSystem;
 	type Channels = EthereumSystem;
 	type WeightToFee = IdentityFee<u128>;
+	type OnNewCommitment = ();
 	type WeightInfo = ();
 }
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -127,6 +127,7 @@ impl snowbridge_pallet_outbound_queue::Config for Runtime {
 	type Channels = EthereumSystem;
 	type AggregateMessageOrigin = AggregateMessageOrigin;
 	type GetAggregateMessageOrigin = GetAggregateMessageOrigin;
+	type OnNewCommitment = ();
 }
 
 #[cfg(any(feature = "std", feature = "fast-runtime", feature = "runtime-benchmarks", test))]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -127,6 +127,7 @@ impl snowbridge_pallet_outbound_queue::Config for Runtime {
 	type Channels = EthereumSystem;
 	type AggregateMessageOrigin = AggregateMessageOrigin;
 	type GetAggregateMessageOrigin = GetAggregateMessageOrigin;
+	type OnNewCommitment = ();
 }
 
 #[cfg(any(feature = "std", feature = "fast-runtime", feature = "runtime-benchmarks", test))]


### PR DESCRIPTION
# Description
This PR adds a commitment hook in outbound queue pallet. This hook is called whenever there is new commitment. Since it is called in `on_finalize` the hook should have as little weight as possible.