### PR TITLE
Girazoki make token id conversion generic

### DIFF
--- a/bridges/snowbridge/pallets/system/Cargo.toml
+++ b/bridges/snowbridge/pallets/system/Cargo.toml
@@ -39,6 +39,7 @@ sp-keyring = { default-features = true, path = "../../../../substrate/primitives
 polkadot-primitives = { default-features = true, path = "../../../../polkadot/primitives" }
 pallet-message-queue = { default-features = true, path = "../../../../substrate/frame/message-queue" }
 snowbridge-pallet-outbound-queue = { default-features = true, path = "../outbound-queue" }
+bridge-hub-common.workspace = true
 
 [features]
 default = ["std"]

--- a/bridges/snowbridge/pallets/system/src/lib.rs
+++ b/bridges/snowbridge/pallets/system/src/lib.rs
@@ -70,7 +70,7 @@ use snowbridge_core::{
 	meth,
 	outbound::{Command, Initializer, Message, OperatingMode, SendError, SendMessage},
 	sibling_sovereign_account, AgentId, AssetMetadata, Channel, ChannelId, ParaId,
-	PricingParameters as PricingParametersRecord, TokenId, TokenIdOf, PRIMARY_GOVERNANCE_CHANNEL,
+	PricingParameters as PricingParametersRecord, TokenId, PRIMARY_GOVERNANCE_CHANNEL,
 	SECONDARY_GOVERNANCE_CHANNEL,
 };
 use sp_core::{RuntimeDebug, H160, H256};
@@ -179,6 +179,9 @@ pub mod pallet {
 
 		// The bridges configured Ethereum location
 		type EthereumLocation: Get<Location>;
+
+		// How to transform a location into token-id
+		type TokenIdFromLocation: ConvertLocation<TokenId>;
 
 		#[cfg(feature = "runtime-benchmarks")]
 		type Helper: BenchmarkHelper<Self::RuntimeOrigin>;
@@ -737,7 +740,7 @@ pub mod pallet {
 				.reanchored(&ethereum_location, &T::UniversalLocation::get())
 				.map_err(|_| Error::<T>::LocationConversionFailed)?;
 
-			let token_id = TokenIdOf::convert_location(&location)
+			let token_id = T::TokenIdFromLocation::convert_location(&location)
 				.ok_or(Error::<T>::LocationConversionFailed)?;
 
 			if !ForeignToNativeId::<T>::contains_key(token_id) {

--- a/bridges/snowbridge/pallets/system/src/mock.rs
+++ b/bridges/snowbridge/pallets/system/src/mock.rs
@@ -10,12 +10,13 @@ use frame_support::{
 use sp_core::H256;
 use xcm_executor::traits::ConvertLocation;
 
+use bridge_hub_common::AggregateMessageOrigin;
 use snowbridge_core::{
 	gwei, meth, outbound::ConstantGasMeter, sibling_sovereign_account, AgentId, AllowSiblingsOnly,
 	ParaId, PricingParameters, Rewards,
 };
 use sp_runtime::{
-	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup, Keccak256},
+	traits::{AccountIdConversion, BlakeTwo256, Convert, IdentityLookup, Keccak256},
 	AccountId32, BuildStorage, FixedU128,
 };
 use xcm::prelude::*;
@@ -148,6 +149,14 @@ parameter_types! {
 	pub const OwnParaId: ParaId = ParaId::new(1013);
 }
 
+pub struct GetAggregateMessageOrigin;
+
+impl Convert<snowbridge_core::ChannelId, AggregateMessageOrigin> for GetAggregateMessageOrigin {
+	fn convert(channel_id: snowbridge_core::ChannelId) -> AggregateMessageOrigin {
+		AggregateMessageOrigin::Snowbridge(channel_id)
+	}
+}
+
 impl snowbridge_pallet_outbound_queue::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Hashing = Keccak256;
@@ -161,6 +170,8 @@ impl snowbridge_pallet_outbound_queue::Config for Test {
 	type Channels = EthereumSystem;
 	type WeightToFee = IdentityFee<u128>;
 	type OnNewCommitment = ();
+	type AggregateMessageOrigin = AggregateMessageOrigin;
+	type GetAggregateMessageOrigin = GetAggregateMessageOrigin;
 	type WeightInfo = ();
 }
 
@@ -212,6 +223,7 @@ impl crate::Config for Test {
 	type InboundDeliveryCost = InboundDeliveryCost;
 	type UniversalLocation = UniversalLocation;
 	type EthereumLocation = EthereumDestination;
+	type TokenIdFromLocation = snowbridge_core::TokenIdOf;
 	#[cfg(feature = "runtime-benchmarks")]
 	type Helper = ();
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -206,6 +206,7 @@ impl snowbridge_pallet_system::Config for Runtime {
 	type InboundDeliveryCost = EthereumInboundQueue;
 	type UniversalLocation = UniversalLocation;
 	type EthereumLocation = EthereumLocation;
+	type TokenIdFromLocation = snowbridge_core::TokenIdOf;
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -203,6 +203,7 @@ impl snowbridge_pallet_system::Config for Runtime {
 	type InboundDeliveryCost = EthereumInboundQueue;
 	type UniversalLocation = UniversalLocation;
 	type EthereumLocation = EthereumLocation;
+	type TokenIdFromLocation = snowbridge_core::TokenIdOf;
 }
 
 #[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
Make token-id conversion in ethereum-system more generic. this should allow us to register tokens as if we were a solo-chain
