### PR TITLE
Add reward processor in snowbridge inbound queue

### DIFF
--- a/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
@@ -86,9 +86,9 @@ impl<T: frame_system::Config> RewardProcessor<T> for () {
 	}
 }
 
-pub struct DeliveryCostReward<T>(sp_std::marker::PhantomData<T>);
+pub struct RewardThroughSovereign<T>(sp_std::marker::PhantomData<T>);
 
-impl<T: pallet::Config> RewardProcessor<T> for DeliveryCostReward<T> {
+impl<T: pallet::Config> RewardProcessor<T> for RewardThroughSovereign<T> {
 	fn process_reward(who: T::AccountId, message: Message) -> DispatchResult {
 		let length = message.encode().len() as u32;
 		let delivery_cost = pallet::Pallet::<T>::calculate_delivery_cost(length);

--- a/bridges/snowbridge/pallets/inbound-queue/src/mock.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/mock.rs
@@ -2,9 +2,6 @@
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 use super::*;
 
-use frame_support::storage::Key;
-use frame_support::traits::tokens::Fortitude;
-use frame_support::traits::tokens::Preservation;
 use frame_support::{derive_impl, parameter_types, traits::ConstU32, weights::IdentityFee};
 use hex_literal::hex;
 use snowbridge_beacon_primitives::{
@@ -17,8 +14,6 @@ use snowbridge_core::{
 };
 use snowbridge_router_primitives::inbound::MessageToXcm;
 use sp_core::{H160, H256};
-use sp_keyring::AccountKeyring as Keyring;
-use sp_runtime::traits::Zero;
 use sp_runtime::{
 	traits::{IdentifyAccount, IdentityLookup, MaybeEquivalence, Verify},
 	BuildStorage, DispatchError, FixedU128, MultiSignature,
@@ -29,7 +24,6 @@ use xcm_executor::AssetsInHolding;
 
 use crate::xcm_message_processor::XcmMessageProcessor;
 use crate::{self as inbound_queue};
-use sp_core::Get;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -249,38 +243,6 @@ impl MessageProcessor for DummySuffix {
 	}
 }
 
-pub struct DeliveryCostReward<T>(sp_std::marker::PhantomData<T>);
-
-impl<T: inbound_queue::Config> RewardProcessor<T> for DeliveryCostReward<T>
-where
-	T: inbound_queue::Config,
-	T::AccountId: From<sp_runtime::AccountId32>,
-{
-	fn process_reward(who: T::AccountId, message: Message) -> DispatchResult {
-		let length = message.encode().len() as u32;
-		let weight_fee = T::WeightToFee::weight_to_fee(&T::WeightInfo::submit());
-		let len_fee = T::LengthToFee::weight_to_fee(&Weight::from_parts(length as u64, 0));
-		let delivery_cost = weight_fee
-			.saturating_add(len_fee)
-			.saturating_add(T::PricingParameters::get().rewards.local);
-
-		let sovereign_account: T::AccountId =
-			sp_runtime::AccountId32::from(Keyring::Alice.public()).into();
-
-		let amount = T::Token::reducible_balance(
-			&sovereign_account,
-			Preservation::Preserve,
-			Fortitude::Polite,
-		)
-		.min(delivery_cost);
-		if !amount.is_zero() {
-			T::Token::transfer(&sovereign_account, &who, amount, Preservation::Preserve)?;
-		}
-
-		Ok(())
-	}
-}
-
 impl inbound_queue::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Verifier = MockVerifier;
@@ -307,7 +269,7 @@ impl inbound_queue::Config for Test {
 	type MaxMessageSize = ConstU32<1024>;
 	type AssetTransactor = SuccessfulTransactor;
 	type MessageProcessor = (DummyPrefix, XcmMessageProcessor<Test>, DummySuffix); // We are passively testing if implementation of MessageProcessor trait works correctly for tuple
-	type RewardProcessor = DeliveryCostReward<Test>;
+	type RewardProcessor = DeliveryCostReward<Self>;
 }
 
 pub fn last_events(n: usize) -> Vec<RuntimeEvent> {
@@ -326,6 +288,16 @@ pub fn expect_events(e: Vec<RuntimeEvent>) {
 
 pub fn setup() {
 	System::set_block_number(1);
+	Balances::mint_into(
+		&sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into()),
+		InitialFund::get(),
+	)
+	.unwrap();
+	Balances::mint_into(
+		&sibling_sovereign_account::<Test>(TEMPLATE_PARAID.into()),
+		InitialFund::get(),
+	)
+	.unwrap();
 }
 
 pub fn new_tester() -> sp_io::TestExternalities {
@@ -412,3 +384,4 @@ pub fn mock_execution_proof() -> ExecutionProof {
 }
 
 pub const ASSET_HUB_PARAID: u32 = 1000u32;
+pub const TEMPLATE_PARAID: u32 = 1001u32;

--- a/bridges/snowbridge/pallets/inbound-queue/src/mock.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/mock.rs
@@ -269,7 +269,7 @@ impl inbound_queue::Config for Test {
 	type MaxMessageSize = ConstU32<1024>;
 	type AssetTransactor = SuccessfulTransactor;
 	type MessageProcessor = (DummyPrefix, XcmMessageProcessor<Test>, DummySuffix); // We are passively testing if implementation of MessageProcessor trait works correctly for tuple
-	type RewardProcessor = DeliveryCostReward<Self>;
+	type RewardProcessor = RewardThroughSovereign<Self>;
 }
 
 pub fn last_events(n: usize) -> Vec<RuntimeEvent> {

--- a/bridges/snowbridge/pallets/inbound-queue/src/test.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/test.rs
@@ -17,9 +17,10 @@ use crate::mock::*;
 fn test_submit_happy_path() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
-		let channel_sovereign = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
-
 		let origin = RuntimeOrigin::signed(relayer.clone());
+
+		// Add funds to reward relayers
+		let _ = Balances::mint_into(&AccountId::from(Keyring::Alice), 1e20 as u128);
 
 		// Submit message
 		let message = Message {
@@ -30,9 +31,7 @@ fn test_submit_happy_path() {
 			},
 		};
 
-		let initial_fund = InitialFund::get();
 		assert_eq!(Balances::balance(&relayer), 0);
-		assert_eq!(Balances::balance(&channel_sovereign), initial_fund);
 
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
 		expect_events(vec![InboundQueueEvent::MessageReceived {
@@ -54,10 +53,6 @@ fn test_submit_happy_path() {
 		);
 
 		assert_eq!(Balances::balance(&relayer), delivery_cost, "relayer was rewarded");
-		assert!(
-			Balances::balance(&channel_sovereign) <= initial_fund - delivery_cost,
-			"sovereign account paid reward"
-		);
 	});
 }
 
@@ -66,11 +61,6 @@ fn test_submit_xcm_invalid_channel() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
-
-		// Deposit funds into sovereign account of parachain 1001
-		let sovereign_account = sibling_sovereign_account::<Test>(TEMPLATE_PARAID.into());
-		println!("account: {}", sovereign_account);
-		let _ = Balances::mint_into(&sovereign_account, 10000);
 
 		// Submit message
 		let message = Message {
@@ -93,10 +83,6 @@ fn test_submit_with_invalid_gateway() {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
 
-		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
-		let _ = Balances::mint_into(&sovereign_account, 10000);
-
 		// Submit message
 		let message = Message {
 			event_log: mock_event_log_invalid_gateway(),
@@ -117,10 +103,6 @@ fn test_submit_with_invalid_nonce() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
-
-		// Deposit funds into sovereign account of Asset Hub (Statemint)
-		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
-		let _ = Balances::mint_into(&sovereign_account, 10000);
 
 		// Submit message
 		let message = Message {
@@ -150,10 +132,6 @@ fn test_submit_no_funds_to_reward_relayers_just_ignore() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
-
-		// Reset balance of sovereign_account to zero first
-		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
-		Balances::set_balance(&sovereign_account, 0);
 
 		// Submit message
 		let message = Message {
@@ -209,10 +187,6 @@ fn test_submit_no_funds_to_reward_relayers_and_ed_preserved() {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
 
-		// Reset balance of sovereign account to (ED+1) first
-		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
-		Balances::set_balance(&sovereign_account, ExistentialDeposit::get() + 1);
-
 		// Submit message successfully
 		let message = Message {
 			event_log: mock_event_log(),
@@ -222,10 +196,6 @@ fn test_submit_no_funds_to_reward_relayers_and_ed_preserved() {
 			},
 		};
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
-
-		// Check balance of sovereign account to ED
-		let amount = Balances::balance(&sovereign_account);
-		assert_eq!(amount, ExistentialDeposit::get());
 
 		// Submit another message with nonce set as 2
 		let mut event_log = mock_event_log();
@@ -238,8 +208,5 @@ fn test_submit_no_funds_to_reward_relayers_and_ed_preserved() {
 			},
 		};
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
-		// Check balance of sovereign account as ED does not change
-		let amount = Balances::balance(&sovereign_account);
-		assert_eq!(amount, ExistentialDeposit::get());
 	});
 }

--- a/bridges/snowbridge/pallets/inbound-queue/src/test.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/test.rs
@@ -17,10 +17,9 @@ use crate::mock::*;
 fn test_submit_happy_path() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
-		let origin = RuntimeOrigin::signed(relayer.clone());
+		let channel_sovereign = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
 
-		// Add funds to reward relayers
-		let _ = Balances::mint_into(&AccountId::from(Keyring::Alice), 1e20 as u128);
+		let origin = RuntimeOrigin::signed(relayer.clone());
 
 		// Submit message
 		let message = Message {
@@ -31,7 +30,9 @@ fn test_submit_happy_path() {
 			},
 		};
 
+		let initial_fund = InitialFund::get();
 		assert_eq!(Balances::balance(&relayer), 0);
+		assert_eq!(Balances::balance(&channel_sovereign), initial_fund);
 
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
 		expect_events(vec![InboundQueueEvent::MessageReceived {
@@ -53,6 +54,10 @@ fn test_submit_happy_path() {
 		);
 
 		assert_eq!(Balances::balance(&relayer), delivery_cost, "relayer was rewarded");
+		assert!(
+			Balances::balance(&channel_sovereign) <= initial_fund - delivery_cost,
+			"sovereign account paid reward"
+		);
 	});
 }
 
@@ -61,6 +66,11 @@ fn test_submit_xcm_invalid_channel() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
+
+		// Deposit funds into sovereign account of parachain 1001
+		let sovereign_account = sibling_sovereign_account::<Test>(TEMPLATE_PARAID.into());
+		println!("account: {}", sovereign_account);
+		let _ = Balances::mint_into(&sovereign_account, 10000);
 
 		// Submit message
 		let message = Message {
@@ -83,6 +93,10 @@ fn test_submit_with_invalid_gateway() {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
 
+		// Deposit funds into sovereign account of Asset Hub (Statemint)
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
+		let _ = Balances::mint_into(&sovereign_account, 10000);
+
 		// Submit message
 		let message = Message {
 			event_log: mock_event_log_invalid_gateway(),
@@ -103,6 +117,10 @@ fn test_submit_with_invalid_nonce() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
+
+		// Deposit funds into sovereign account of Asset Hub (Statemint)
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
+		let _ = Balances::mint_into(&sovereign_account, 10000);
 
 		// Submit message
 		let message = Message {
@@ -132,6 +150,10 @@ fn test_submit_no_funds_to_reward_relayers_just_ignore() {
 	new_tester().execute_with(|| {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
+
+		// Reset balance of sovereign_account to zero first
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
+		Balances::set_balance(&sovereign_account, 0);
 
 		// Submit message
 		let message = Message {
@@ -187,6 +209,10 @@ fn test_submit_no_funds_to_reward_relayers_and_ed_preserved() {
 		let relayer: AccountId = Keyring::Bob.into();
 		let origin = RuntimeOrigin::signed(relayer);
 
+		// Reset balance of sovereign account to (ED+1) first
+		let sovereign_account = sibling_sovereign_account::<Test>(ASSET_HUB_PARAID.into());
+		Balances::set_balance(&sovereign_account, ExistentialDeposit::get() + 1);
+
 		// Submit message successfully
 		let message = Message {
 			event_log: mock_event_log(),
@@ -196,6 +222,10 @@ fn test_submit_no_funds_to_reward_relayers_and_ed_preserved() {
 			},
 		};
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
+
+		// Check balance of sovereign account to ED
+		let amount = Balances::balance(&sovereign_account);
+		assert_eq!(amount, ExistentialDeposit::get());
 
 		// Submit another message with nonce set as 2
 		let mut event_log = mock_event_log();
@@ -208,5 +238,8 @@ fn test_submit_no_funds_to_reward_relayers_and_ed_preserved() {
 			},
 		};
 		assert_ok!(InboundQueue::submit(origin.clone(), message.clone()));
+		// Check balance of sovereign account as ED does not change
+		let amount = Balances::balance(&sovereign_account);
+		assert_eq!(amount, ExistentialDeposit::get());
 	});
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -30,7 +30,7 @@ use pallet_xcm::EnsureXcm;
 use parachains_common::{AccountId, Balance};
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use snowbridge_core::{gwei, meth, AllowSiblingsOnly, ChannelId, PricingParameters, Rewards};
-use snowbridge_pallet_inbound_queue::DeliveryCostReward;
+use snowbridge_pallet_inbound_queue::RewardThroughSovereign;
 use snowbridge_router_primitives::{inbound::MessageToXcm, outbound::EthereumBlobExporter};
 use sp_core::H160;
 use sp_runtime::traits::Convert;
@@ -102,7 +102,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type AssetTransactor = <xcm_config::XcmConfig as xcm_executor::Config>::AssetTransactor;
 	type MessageProcessor =
 		snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
-	type RewardProcessor = DeliveryCostReward<Self>;
+	type RewardProcessor = RewardThroughSovereign<Self>;
 }
 
 pub struct GetAggregateMessageOrigin;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::xcm_config::RelayNetwork;
 #[cfg(not(feature = "runtime-benchmarks"))]
 use crate::XcmRouter;
 use crate::{
@@ -21,26 +22,25 @@ use crate::{
 	EthereumOutboundQueue, EthereumSystem, MessageQueue, Runtime, RuntimeEvent, TransactionByteFee,
 	TreasuryAccount,
 };
+#[cfg(feature = "runtime-benchmarks")]
+use benchmark_helpers::DoNothingRouter;
+use bridge_hub_common::AggregateMessageOrigin;
+use frame_support::{parameter_types, weights::ConstantMultiplier};
+use pallet_xcm::EnsureXcm;
 use parachains_common::{AccountId, Balance};
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use snowbridge_core::{gwei, meth, AllowSiblingsOnly, ChannelId, PricingParameters, Rewards};
-use sp_runtime::traits::Convert;
 use snowbridge_router_primitives::{inbound::MessageToXcm, outbound::EthereumBlobExporter};
 use sp_core::H160;
+use sp_runtime::traits::Convert;
+use sp_runtime::{
+	traits::{ConstU32, ConstU8, Keccak256},
+	FixedU128,
+};
 use testnet_parachains_constants::rococo::{
 	currency::*,
 	fee::WeightToFee,
 	snowbridge::{EthereumLocation, EthereumNetwork, INBOUND_QUEUE_PALLET_INDEX},
-};
-use bridge_hub_common::AggregateMessageOrigin;
-use crate::xcm_config::RelayNetwork;
-#[cfg(feature = "runtime-benchmarks")]
-use benchmark_helpers::DoNothingRouter;
-use frame_support::{parameter_types, weights::ConstantMultiplier};
-use pallet_xcm::EnsureXcm;
-use sp_runtime::{
-	traits::{ConstU32, ConstU8, Keccak256},
-	FixedU128,
 };
 use xcm::prelude::{GlobalConsensus, InteriorLocation, Location, Parachain};
 
@@ -99,18 +99,18 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type WeightInfo = crate::weights::snowbridge_pallet_inbound_queue::WeightInfo<Runtime>;
 	type PricingParameters = EthereumSystem;
 	type AssetTransactor = <xcm_config::XcmConfig as xcm_executor::Config>::AssetTransactor;
-	type MessageProcessor = snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
+	type MessageProcessor =
+		snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
+	type RewardProcessor = ();
 }
-
 
 pub struct GetAggregateMessageOrigin;
 
 impl Convert<ChannelId, AggregateMessageOrigin> for GetAggregateMessageOrigin {
-    fn convert(channel_id: ChannelId) -> AggregateMessageOrigin {
-        AggregateMessageOrigin::Snowbridge(channel_id)
-    }
+	fn convert(channel_id: ChannelId) -> AggregateMessageOrigin {
+		AggregateMessageOrigin::Snowbridge(channel_id)
+	}
 }
-
 
 impl snowbridge_pallet_outbound_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_ethereum_config.rs
@@ -30,6 +30,7 @@ use pallet_xcm::EnsureXcm;
 use parachains_common::{AccountId, Balance};
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use snowbridge_core::{gwei, meth, AllowSiblingsOnly, ChannelId, PricingParameters, Rewards};
+use snowbridge_pallet_inbound_queue::DeliveryCostReward;
 use snowbridge_router_primitives::{inbound::MessageToXcm, outbound::EthereumBlobExporter};
 use sp_core::H160;
 use sp_runtime::traits::Convert;
@@ -101,7 +102,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type AssetTransactor = <xcm_config::XcmConfig as xcm_executor::Config>::AssetTransactor;
 	type MessageProcessor =
 		snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
-	type RewardProcessor = ();
+	type RewardProcessor = DeliveryCostReward<Self>;
 }
 
 pub struct GetAggregateMessageOrigin;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -103,7 +103,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type AssetTransactor = <xcm_config::XcmConfig as xcm_executor::Config>::AssetTransactor;
 	type MessageProcessor =
 		snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
-	type RewardProcessor = ();
+	type RewardProcessor = DeliveryCostReward<Self>;
 }
 
 pub struct GetAggregateMessageOrigin;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -31,6 +31,7 @@ use pallet_xcm::EnsureXcm;
 use parachains_common::{AccountId, Balance};
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use snowbridge_core::{gwei, meth, AllowSiblingsOnly, ChannelId, PricingParameters, Rewards};
+use snowbridge_pallet_inbound_queue::RewardThroughSovereign;
 use snowbridge_router_primitives::{inbound::MessageToXcm, outbound::EthereumBlobExporter};
 use sp_core::H160;
 use sp_runtime::traits::Convert;
@@ -103,7 +104,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type AssetTransactor = <xcm_config::XcmConfig as xcm_executor::Config>::AssetTransactor;
 	type MessageProcessor =
 		snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
-	type RewardProcessor = DeliveryCostReward<Self>;
+	type RewardProcessor = RewardThroughSovereign<Self>;
 }
 
 pub struct GetAggregateMessageOrigin;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::xcm_config::RelayNetwork;
 #[cfg(not(feature = "runtime-benchmarks"))]
 use crate::XcmRouter;
 use crate::{
@@ -22,26 +23,25 @@ use crate::{
 	Balances, EthereumInboundQueue, EthereumOutboundQueue, EthereumSystem, MessageQueue, Runtime,
 	RuntimeEvent, TransactionByteFee,
 };
+#[cfg(feature = "runtime-benchmarks")]
+use benchmark_helpers::DoNothingRouter;
+use bridge_hub_common::AggregateMessageOrigin;
+use frame_support::{parameter_types, weights::ConstantMultiplier};
+use pallet_xcm::EnsureXcm;
 use parachains_common::{AccountId, Balance};
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use snowbridge_core::{gwei, meth, AllowSiblingsOnly, ChannelId, PricingParameters, Rewards};
 use snowbridge_router_primitives::{inbound::MessageToXcm, outbound::EthereumBlobExporter};
 use sp_core::H160;
+use sp_runtime::traits::Convert;
+use sp_runtime::{
+	traits::{ConstU32, ConstU8, Keccak256},
+	FixedU128,
+};
 use testnet_parachains_constants::westend::{
 	currency::*,
 	fee::WeightToFee,
 	snowbridge::{EthereumLocation, EthereumNetwork, INBOUND_QUEUE_PALLET_INDEX},
-};
-use sp_runtime::traits::Convert;
-use bridge_hub_common::AggregateMessageOrigin;
-use crate::xcm_config::RelayNetwork;
-#[cfg(feature = "runtime-benchmarks")]
-use benchmark_helpers::DoNothingRouter;
-use frame_support::{parameter_types, weights::ConstantMultiplier};
-use pallet_xcm::EnsureXcm;
-use sp_runtime::{
-	traits::{ConstU32, ConstU8, Keccak256},
-	FixedU128,
 };
 use xcm::prelude::{GlobalConsensus, InteriorLocation, Location, Parachain};
 
@@ -101,15 +101,17 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
 	type WeightInfo = crate::weights::snowbridge_pallet_inbound_queue::WeightInfo<Runtime>;
 	type PricingParameters = EthereumSystem;
 	type AssetTransactor = <xcm_config::XcmConfig as xcm_executor::Config>::AssetTransactor;
-	type MessageProcessor = snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
+	type MessageProcessor =
+		snowbridge_pallet_inbound_queue::xcm_message_processor::XcmMessageProcessor<Runtime>;
+	type RewardProcessor = ();
 }
 
 pub struct GetAggregateMessageOrigin;
 
 impl Convert<ChannelId, AggregateMessageOrigin> for GetAggregateMessageOrigin {
-    fn convert(channel_id: ChannelId) -> AggregateMessageOrigin {
-        AggregateMessageOrigin::Snowbridge(channel_id)
-    }
+	fn convert(channel_id: ChannelId) -> AggregateMessageOrigin {
+		AggregateMessageOrigin::Snowbridge(channel_id)
+	}
 }
 
 impl snowbridge_pallet_outbound_queue::Config for Runtime {


### PR DESCRIPTION
# Description

Introduce reward processor to add more flexibility in order to reward the relayer from the snowbridge inbound queue messages

- [x] New trait `RewardProcessor` with `process_reward` func
- [x] Mocks
- [x] Fix tests  