### PR TITLE
Re introduce snowbridge v1 removed extrinsics

### DIFF
--- a/bridges/snowbridge/pallets/system/src/lib.rs
+++ b/bridges/snowbridge/pallets/system/src/lib.rs
@@ -52,7 +52,10 @@ use snowbridge_outbound_queue_primitives::{
 };
 use sp_core::{RuntimeDebug, H160, H256};
 use sp_io::hashing::blake2_256;
-use sp_runtime::{traits::MaybeEquivalence, DispatchError, SaturatedConversion};
+use sp_runtime::{
+	traits::{BadOrigin, MaybeEquivalence},
+	DispatchError, SaturatedConversion,
+};
 use sp_std::prelude::*;
 use xcm::prelude::*;
 use xcm_executor::traits::ConvertLocation;
@@ -66,6 +69,20 @@ pub type BalanceOf<T> =
 	<<T as pallet::Config>::Token as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type PricingParametersOf<T> = PricingParametersRecord<BalanceOf<T>>;
+
+/// Ensure origin location is a sibling
+fn ensure_sibling<T>(location: &Location) -> Result<(ParaId, H256), DispatchError>
+where
+	T: Config,
+{
+	match location.unpack() {
+		(1, [Parachain(para_id)]) => {
+			let agent_id = agent_id_of::<T>(location)?;
+			Ok(((*para_id).into(), agent_id))
+		},
+		_ => Err(BadOrigin.into()),
+	}
+}
 
 /// Hash the location to produce an agent id
 pub fn agent_id_of<T: Config>(location: &Location) -> Result<H256, DispatchError> {
@@ -337,6 +354,69 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Sends a message to the Gateway contract to update an arbitrary channel
+		///
+		/// Fee required: No
+		///
+		/// - `origin`: Must be root
+		/// - `channel_id`: ID of channel
+		/// - `mode`: Initial operating mode of the channel
+		/// - `outbound_fee`: Fee charged to users for sending outbound messages to Polkadot
+		#[pallet::call_index(6)]
+		#[pallet::weight(T::WeightInfo::force_update_channel())]
+		pub fn force_update_channel(
+			origin: OriginFor<T>,
+			channel_id: ChannelId,
+			mode: OperatingMode,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+
+			ensure!(Channels::<T>::contains_key(channel_id), Error::<T>::NoChannel);
+
+			let command = Command::UpdateChannel { channel_id, mode };
+			Self::send(PRIMARY_GOVERNANCE_CHANNEL, command, PaysFee::<T>::No)?;
+
+			Self::deposit_event(Event::<T>::UpdateChannel { channel_id, mode });
+			Ok(())
+		}
+
+		/// Sends a message to the Gateway contract to transfer ether from an agent to `recipient`.
+		///
+		/// Privileged. Can only be called by root.
+		///
+		/// Fee required: No
+		///
+		/// - `origin`: Must be root
+		/// - `location`: Location used to resolve the agent
+		/// - `recipient`: Recipient of funds
+		/// - `amount`: Amount to transfer
+		#[pallet::call_index(8)]
+		#[pallet::weight(T::WeightInfo::force_transfer_native_from_agent())]
+		pub fn force_transfer_native_from_agent(
+			origin: OriginFor<T>,
+			location: Box<VersionedLocation>,
+			recipient: H160,
+			amount: u128,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+
+			// Ensure that location is some consensus system on a sibling parachain
+			let location: Location =
+				(*location).try_into().map_err(|_| Error::<T>::UnsupportedLocationVersion)?;
+			let (_, agent_id) =
+				ensure_sibling::<T>(&location).map_err(|_| Error::<T>::InvalidLocation)?;
+
+			let pays_fee = PaysFee::<T>::No;
+
+			Self::do_transfer_native_from_agent(
+				agent_id,
+				PRIMARY_GOVERNANCE_CHANNEL,
+				recipient,
+				amount,
+				pays_fee,
+			)
+		}
+
 		/// Sends a message to the Gateway contract to update fee related parameters for
 		/// token transfers.
 		///
@@ -434,6 +514,28 @@ pub mod pallet {
 			}
 
 			T::OutboundQueue::deliver(ticket).map_err(|err| Error::<T>::Send(err))?;
+			Ok(())
+		}
+
+		/// Issue a `Command::TransferNativeFromAgent` command. The command will be sent on the
+		/// channel `channel_id`
+		pub fn do_transfer_native_from_agent(
+			agent_id: H256,
+			channel_id: ChannelId,
+			recipient: H160,
+			amount: u128,
+			pays_fee: PaysFee<T>,
+		) -> DispatchResult {
+			ensure!(Agents::<T>::contains_key(agent_id), Error::<T>::NoAgent);
+
+			let command = Command::TransferNativeFromAgent { agent_id, recipient, amount };
+			Self::send(channel_id, command, pays_fee)?;
+
+			Self::deposit_event(Event::<T>::TransferNativeFromAgent {
+				agent_id,
+				recipient,
+				amount,
+			});
 			Ok(())
 		}
 

--- a/bridges/snowbridge/pallets/system/src/weights.rs
+++ b/bridges/snowbridge/pallets/system/src/weights.rs
@@ -37,6 +37,8 @@ pub trait WeightInfo {
 	fn set_token_transfer_fees() -> Weight;
 	fn set_pricing_parameters() -> Weight;
 	fn register_token() -> Weight;
+	fn force_update_channel() -> Weight;
+	fn force_transfer_native_from_agent() -> Weight;
 }
 
 // For backwards compatibility and tests.
@@ -60,6 +62,25 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(4_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
+	/// Storage: EthereumSystem Channels (r:1 w:0)
+	/// Proof: EthereumSystem Channels (max_values: None, max_size: Some(12), added: 2487, mode: MaxEncodedLen)
+	/// Storage: EthereumOutboundQueue PalletOperatingMode (r:1 w:0)
+	/// Proof: EthereumOutboundQueue PalletOperatingMode (max_values: Some(1), max_size: Some(1), added: 496, mode: MaxEncodedLen)
+	/// Storage: MessageQueue BookStateFor (r:2 w:2)
+	/// Proof: MessageQueue BookStateFor (max_values: None, max_size: Some(52), added: 2527, mode: MaxEncodedLen)
+	/// Storage: MessageQueue ServiceHead (r:1 w:0)
+	/// Proof: MessageQueue ServiceHead (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: MessageQueue Pages (r:0 w:1)
+	/// Proof: MessageQueue Pages (max_values: None, max_size: Some(65585), added: 68060, mode: MaxEncodedLen)
+	fn force_update_channel() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `256`
+		//  Estimated: `6044`
+		// Minimum execution time: 41_000_000 picoseconds.
+		Weight::from_parts(41_000_000, 6044)
+			.saturating_add(RocksDbWeight::get().reads(5_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
 	/// Storage: ParachainInfo ParachainId (r:1 w:0)
 	/// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
 	/// Storage: EthereumOutboundQueue PalletOperatingMode (r:1 w:0)
@@ -77,6 +98,25 @@ impl WeightInfo for () {
 		// Minimum execution time: 31_000_000 picoseconds.
 		Weight::from_parts(31_000_000, 3517)
 			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	/// Storage: EthereumSystem Agents (r:1 w:0)
+	/// Proof: EthereumSystem Agents (max_values: None, max_size: Some(40), added: 2515, mode: MaxEncodedLen)
+	/// Storage: EthereumOutboundQueue PalletOperatingMode (r:1 w:0)
+	/// Proof: EthereumOutboundQueue PalletOperatingMode (max_values: Some(1), max_size: Some(1), added: 496, mode: MaxEncodedLen)
+	/// Storage: MessageQueue BookStateFor (r:2 w:2)
+	/// Proof: MessageQueue BookStateFor (max_values: None, max_size: Some(52), added: 2527, mode: MaxEncodedLen)
+	/// Storage: MessageQueue ServiceHead (r:1 w:0)
+	/// Proof: MessageQueue ServiceHead (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: MessageQueue Pages (r:0 w:1)
+	/// Proof: MessageQueue Pages (max_values: None, max_size: Some(65585), added: 68060, mode: MaxEncodedLen)
+	fn force_transfer_native_from_agent() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `252`
+		//  Estimated: `6044`
+		// Minimum execution time: 42_000_000 picoseconds.
+		Weight::from_parts(42_000_000, 6044)
+			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 	/// Storage: ParachainInfo ParachainId (r:1 w:0)

--- a/bridges/snowbridge/primitives/outbound-queue/src/v1/message.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v1/message.rs
@@ -6,7 +6,7 @@ use crate::{OperatingMode, SendError, SendMessageFeeProvider};
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use ethabi::Token;
 use scale_info::TypeInfo;
-use snowbridge_core::{pricing::UD60x18, ChannelId};
+use snowbridge_core::{pricing::UD60x18, AgentId, ChannelId};
 use sp_arithmetic::traits::{BaseArithmetic, Unsigned};
 use sp_core::{RuntimeDebug, H160, H256, U256};
 use sp_std::{borrow::ToOwned, vec, vec::Vec};
@@ -74,11 +74,15 @@ pub enum Command {
 		/// Optionally invoke an initializer in the implementation contract
 		initializer: Option<Initializer>,
 	},
+	/// An UpdateChannel message was sent to the Gateway
+	UpdateChannel { channel_id: ChannelId, mode: OperatingMode },
 	/// Set the global operating mode of the Gateway contract
 	SetOperatingMode {
 		/// The new operating mode
 		mode: OperatingMode,
 	},
+	/// An TransferNativeFromAgent message was sent to the Gateway
+	TransferNativeFromAgent { agent_id: AgentId, recipient: H160, amount: u128 },
 	/// Set token fees of the Gateway contract
 	SetTokenTransferFees {
 		/// The fee(DOT) for the cost of creating asset on AssetHub
@@ -136,7 +140,9 @@ impl Command {
 		match self {
 			Command::AgentExecute { .. } => 0,
 			Command::Upgrade { .. } => 1,
+			Command::UpdateChannel { .. } => 4,
 			Command::SetOperatingMode { .. } => 5,
+			Command::TransferNativeFromAgent { .. } => 6,
 			Command::SetTokenTransferFees { .. } => 7,
 			Command::SetPricingParameters { .. } => 8,
 			Command::UnlockNativeToken { .. } => 9,
@@ -152,14 +158,27 @@ impl Command {
 				Token::FixedBytes(agent_id.as_bytes().to_owned()),
 				Token::Bytes(command.abi_encode()),
 			])]),
-			Command::Upgrade { impl_address, impl_code_hash, initializer, .. } =>
+			Command::Upgrade { impl_address, impl_code_hash, initializer, .. } => {
 				ethabi::encode(&[Token::Tuple(vec![
 					Token::Address(*impl_address),
 					Token::FixedBytes(impl_code_hash.as_bytes().to_owned()),
 					initializer.clone().map_or(Token::Bytes(vec![]), |i| Token::Bytes(i.params)),
-				])]),
-			Command::SetOperatingMode { mode } =>
-				ethabi::encode(&[Token::Tuple(vec![Token::Uint(U256::from((*mode) as u64))])]),
+				])])
+			},
+			Command::UpdateChannel { channel_id, mode } => ethabi::encode(&[Token::Tuple(vec![
+				Token::FixedBytes(channel_id.as_ref().to_owned()),
+				Token::Uint(U256::from((*mode) as u64)),
+			])]),
+			Command::SetOperatingMode { mode } => {
+				ethabi::encode(&[Token::Tuple(vec![Token::Uint(U256::from((*mode) as u64))])])
+			},
+			Command::TransferNativeFromAgent { agent_id, recipient, amount } => {
+				ethabi::encode(&[Token::Tuple(vec![
+					Token::FixedBytes(agent_id.as_bytes().to_owned()),
+					Token::Address(*recipient),
+					Token::Uint(U256::from(*amount)),
+				])])
+			},
 			Command::SetTokenTransferFees {
 				create_asset_xcm,
 				transfer_asset_xcm,
@@ -169,32 +188,36 @@ impl Command {
 				Token::Uint(U256::from(*transfer_asset_xcm)),
 				Token::Uint(*register_token),
 			])]),
-			Command::SetPricingParameters { exchange_rate, delivery_cost, multiplier } =>
+			Command::SetPricingParameters { exchange_rate, delivery_cost, multiplier } => {
 				ethabi::encode(&[Token::Tuple(vec![
 					Token::Uint(exchange_rate.clone().into_inner()),
 					Token::Uint(U256::from(*delivery_cost)),
 					Token::Uint(multiplier.clone().into_inner()),
-				])]),
-			Command::UnlockNativeToken { agent_id, token, recipient, amount } =>
+				])])
+			},
+			Command::UnlockNativeToken { agent_id, token, recipient, amount } => {
 				ethabi::encode(&[Token::Tuple(vec![
 					Token::FixedBytes(agent_id.as_bytes().to_owned()),
 					Token::Address(*token),
 					Token::Address(*recipient),
 					Token::Uint(U256::from(*amount)),
-				])]),
-			Command::RegisterForeignToken { token_id, name, symbol, decimals } =>
+				])])
+			},
+			Command::RegisterForeignToken { token_id, name, symbol, decimals } => {
 				ethabi::encode(&[Token::Tuple(vec![
 					Token::FixedBytes(token_id.as_bytes().to_owned()),
 					Token::String(name.to_owned()),
 					Token::String(symbol.to_owned()),
 					Token::Uint(U256::from(*decimals)),
-				])]),
-			Command::MintForeignToken { token_id, recipient, amount } =>
+				])])
+			},
+			Command::MintForeignToken { token_id, recipient, amount } => {
 				ethabi::encode(&[Token::Tuple(vec![
 					Token::FixedBytes(token_id.as_bytes().to_owned()),
 					Token::Address(*recipient),
 					Token::Uint(U256::from(*amount)),
-				])]),
+				])])
+			},
 		}
 	}
 }
@@ -360,6 +383,8 @@ impl GasMeter for ConstantGasMeter {
 				// the the initializer is called.
 				50_000 + initializer_max_gas
 			},
+			Command::UpdateChannel { .. } => 50_000,
+			Command::TransferNativeFromAgent { .. } => 60_000,
 			Command::SetTokenTransferFees { .. } => 60_000,
 			Command::SetPricingParameters { .. } => 60_000,
 			Command::UnlockNativeToken { .. } => 200_000,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/snowbridge_pallet_system.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/snowbridge_pallet_system.rs
@@ -70,6 +70,26 @@ impl<T: frame_system::Config> snowbridge_pallet_system::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	/// Storage: EthereumSystem Channels (r:1 w:0)
+	/// Proof: EthereumSystem Channels (max_values: None, max_size: Some(12), added: 2487, mode: MaxEncodedLen)
+	/// Storage: EthereumOutboundQueue PalletOperatingMode (r:1 w:0)
+	/// Proof: EthereumOutboundQueue PalletOperatingMode (max_values: Some(1), max_size: Some(1), added: 496, mode: MaxEncodedLen)
+	/// Storage: MessageQueue BookStateFor (r:2 w:2)
+	/// Proof: MessageQueue BookStateFor (max_values: None, max_size: Some(52), added: 2527, mode: MaxEncodedLen)
+	/// Storage: MessageQueue ServiceHead (r:1 w:0)
+	/// Proof: MessageQueue ServiceHead (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: MessageQueue Pages (r:0 w:1)
+	/// Proof: MessageQueue Pages (max_values: None, max_size: Some(65585), added: 68060, mode: MaxEncodedLen)
+	fn force_update_channel() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `256`
+		//  Estimated: `6044`
+		// Minimum execution time: 41_000_000 picoseconds.
+		Weight::from_parts(41_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6044))
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 	/// Storage: `EthereumSystem::Channels` (r:1 w:0)
 	/// Proof: `EthereumSystem::Channels` (`max_values`: None, `max_size`: Some(76), added: 2551, mode: `MaxEncodedLen`)
 	/// Storage: `EthereumSystem::PricingParameters` (r:1 w:0)
@@ -88,6 +108,26 @@ impl<T: frame_system::Config> snowbridge_pallet_system::WeightInfo for WeightInf
 		Weight::from_parts(35_339_000, 0)
 			.saturating_add(Weight::from_parts(0, 3601))
 			.saturating_add(T::DbWeight::get().reads(4))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
+	/// Storage: EthereumSystem Agents (r:1 w:0)
+	/// Proof: EthereumSystem Agents (max_values: None, max_size: Some(40), added: 2515, mode: MaxEncodedLen)
+	/// Storage: EthereumOutboundQueue PalletOperatingMode (r:1 w:0)
+	/// Proof: EthereumOutboundQueue PalletOperatingMode (max_values: Some(1), max_size: Some(1), added: 496, mode: MaxEncodedLen)
+	/// Storage: MessageQueue BookStateFor (r:2 w:2)
+	/// Proof: MessageQueue BookStateFor (max_values: None, max_size: Some(52), added: 2527, mode: MaxEncodedLen)
+	/// Storage: MessageQueue ServiceHead (r:1 w:0)
+	/// Proof: MessageQueue ServiceHead (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: MessageQueue Pages (r:0 w:1)
+	/// Proof: MessageQueue Pages (max_values: None, max_size: Some(65585), added: 68060, mode: MaxEncodedLen)
+	fn force_transfer_native_from_agent() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `252`
+		//  Estimated: `6044`
+		// Minimum execution time: 42_000_000 picoseconds.
+		Weight::from_parts(42_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6044))
+			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
 	/// Storage: `EthereumSystem::Channels` (r:1 w:0)

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/snowbridge_pallet_system.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/snowbridge_pallet_system.rs
@@ -70,6 +70,26 @@ impl<T: frame_system::Config> snowbridge_pallet_system::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	/// Storage: EthereumSystem Channels (r:1 w:0)
+	/// Proof: EthereumSystem Channels (max_values: None, max_size: Some(12), added: 2487, mode: MaxEncodedLen)
+	/// Storage: EthereumOutboundQueue PalletOperatingMode (r:1 w:0)
+	/// Proof: EthereumOutboundQueue PalletOperatingMode (max_values: Some(1), max_size: Some(1), added: 496, mode: MaxEncodedLen)
+	/// Storage: MessageQueue BookStateFor (r:2 w:2)
+	/// Proof: MessageQueue BookStateFor (max_values: None, max_size: Some(52), added: 2527, mode: MaxEncodedLen)
+	/// Storage: MessageQueue ServiceHead (r:1 w:0)
+	/// Proof: MessageQueue ServiceHead (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: MessageQueue Pages (r:0 w:1)
+	/// Proof: MessageQueue Pages (max_values: None, max_size: Some(65585), added: 68060, mode: MaxEncodedLen)
+	fn force_update_channel() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `256`
+		//  Estimated: `6044`
+		// Minimum execution time: 41_000_000 picoseconds.
+		Weight::from_parts(41_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6044))
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 	/// Storage: `EthereumSystem::Channels` (r:1 w:0)
 	/// Proof: `EthereumSystem::Channels` (`max_values`: None, `max_size`: Some(76), added: 2551, mode: `MaxEncodedLen`)
 	/// Storage: `EthereumSystem::PricingParameters` (r:1 w:0)
@@ -88,6 +108,26 @@ impl<T: frame_system::Config> snowbridge_pallet_system::WeightInfo for WeightInf
 		Weight::from_parts(30_447_000, 0)
 			.saturating_add(Weight::from_parts(0, 3601))
 			.saturating_add(T::DbWeight::get().reads(4))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
+	/// Storage: EthereumSystem Agents (r:1 w:0)
+	/// Proof: EthereumSystem Agents (max_values: None, max_size: Some(40), added: 2515, mode: MaxEncodedLen)
+	/// Storage: EthereumOutboundQueue PalletOperatingMode (r:1 w:0)
+	/// Proof: EthereumOutboundQueue PalletOperatingMode (max_values: Some(1), max_size: Some(1), added: 496, mode: MaxEncodedLen)
+	/// Storage: MessageQueue BookStateFor (r:2 w:2)
+	/// Proof: MessageQueue BookStateFor (max_values: None, max_size: Some(52), added: 2527, mode: MaxEncodedLen)
+	/// Storage: MessageQueue ServiceHead (r:1 w:0)
+	/// Proof: MessageQueue ServiceHead (max_values: Some(1), max_size: Some(5), added: 500, mode: MaxEncodedLen)
+	/// Storage: MessageQueue Pages (r:0 w:1)
+	/// Proof: MessageQueue Pages (max_values: None, max_size: Some(65585), added: 68060, mode: MaxEncodedLen)
+	fn force_transfer_native_from_agent() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `252`
+		//  Estimated: `6044`
+		// Minimum execution time: 42_000_000 picoseconds.
+		Weight::from_parts(42_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6044))
+			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
 	/// Storage: `EthereumSystem::Channels` (r:1 w:0)


### PR DESCRIPTION
# Description

Reintroduce previously removed snowbridge v1 extrinsics that we might need in case of an emergency.

- force_update_channel
- force_transfer_native_from_agent

Also added the required types and structs to make it work