### PR TITLE
Inbound queue benchmarks helper

### DIFF
--- a/bridges/snowbridge/pallets/inbound-queue/src/benchmarking/mod.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/benchmarking/mod.rs
@@ -16,12 +16,7 @@ mod benchmarks {
 	fn submit() -> Result<(), BenchmarkError> {
 		let caller: T::AccountId = whitelisted_caller();
 
-		let create_message = make_register_token_message();
-
-		T::Helper::initialize_storage(
-			create_message.finalized_header,
-			create_message.block_roots_root,
-		);
+		let create_message = T::Helper::initialize_storage();
 
 		let sovereign_account = sibling_sovereign_account::<T>(1000u32.into());
 

--- a/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
@@ -71,6 +71,8 @@ pub use weights::WeightInfo;
 
 #[cfg(feature = "runtime-benchmarks")]
 use snowbridge_beacon_primitives::BeaconHeader;
+#[cfg(feature = "runtime-benchmarks")]
+use snowbridge_inbound_queue_primitives::v1::EventFixture;
 
 type BalanceOf<T> =
 	<<T as pallet::Config>::Token as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
@@ -126,7 +128,7 @@ pub mod pallet {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	pub trait BenchmarkHelper<T> {
-		fn initialize_storage(beacon_header: BeaconHeader, block_roots_root: H256);
+		fn initialize_storage() -> EventFixture;
 	}
 
 	#[pallet::config]


### PR DESCRIPTION
# Description

Improve the usage of the `inbound_queue::BenchmarkHelper` to decouple the mocks from the benchmark.
This change will enable us to benchmark the pallet using different `MessageProcessors` 