### PR TITLE
WIP update alloy deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives 0.8.25",
+ "alloy-primitives",
  "alloy-rlp",
- "alloy-sol-types 0.8.25",
+ "alloy-sol-types",
 ]
 
 [[package]]
@@ -145,9 +145,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.25",
+ "alloy-primitives",
  "alloy-sol-type-parser",
- "alloy-sol-types 0.8.25",
+ "alloy-sol-types",
  "const-hex",
  "itoa",
  "serde",
@@ -161,27 +161,10 @@ version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
 dependencies = [
- "alloy-primitives 0.8.25",
+ "alloy-primitives",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0628ec0ba5b98b3370bb6be17b12f23bfce8ee4ad83823325a20546d9b03b78"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 0.99.20",
- "hex-literal",
- "itoa",
- "ruint",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -223,23 +206,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a98ad1696a2e17f010ae8e43e9f2a1e930ed176a8e3ff77acfeff6dfb07b42c"
-dependencies = [
- "const-hex",
- "dunce",
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
- "syn-solidity 0.4.2",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
@@ -266,7 +232,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.104",
- "syn-solidity 0.8.25",
+ "syn-solidity",
  "tiny-keccak",
 ]
 
@@ -283,7 +249,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.104",
- "syn-solidity 0.8.25",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -298,24 +264,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d7107bed88e8f09f0ddcc3335622d87bfb6821f3e0c7473329fb1cfad5e015"
-dependencies = [
- "alloy-primitives 0.4.2",
- "alloy-sol-macro 0.4.2",
- "const-hex",
-]
-
-[[package]]
-name = "alloy-sol-types"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.25",
- "alloy-sol-macro 0.8.25",
+ "alloy-primitives",
+ "alloy-sol-macro",
  "const-hex",
  "serde",
 ]
@@ -21474,8 +21429,6 @@ name = "snowbridge-inbound-queue-primitives"
 version = "0.2.1"
 dependencies = [
  "alloy-core",
- "alloy-primitives 0.4.2",
- "alloy-sol-types 0.4.2",
  "frame-support",
  "frame-system",
  "hex-literal",
@@ -25119,18 +25072,6 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b837ef12ab88835251726eb12237655e61ec8dc8a280085d1961cdc3dfd047"
-dependencies = [
- "paste",
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,9 +1637,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "binary-merkle-tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -607,8 +607,6 @@ zero-prefixed-literal = { level = "allow", priority = 2 }            # 00_1000_0
 Inflector = { version = "0.11.4" }
 aes-gcm = { version = "0.10" }
 ahash = { version = "0.8.2" }
-alloy-primitives = { version = "0.4.2", default-features = false }
-alloy-sol-types = { version = "0.4.2", default-features = false }
 alloy-core = { version = "0.8.15", default-features = false }
 always-assert = { version = "0.1" }
 anyhow = { version = "1.0.81", default-features = false }

--- a/bridges/snowbridge/primitives/inbound-queue/Cargo.toml
+++ b/bridges/snowbridge/primitives/inbound-queue/Cargo.toml
@@ -15,8 +15,6 @@ workspace = true
 exclude-from-umbrella = true
 
 [dependencies]
-alloy-primitives = { features = ["rlp"], workspace = true }
-alloy-sol-types = { workspace = true }
 alloy-core = { workspace = true, features = ["sol-types"] }
 codec = { workspace = true }
 frame-support.workspace = true

--- a/bridges/snowbridge/primitives/inbound-queue/src/envelope.rs
+++ b/bridges/snowbridge/primitives/inbound-queue/src/envelope.rs
@@ -6,8 +6,9 @@ use snowbridge_verification_primitives::Log;
 use sp_core::{RuntimeDebug, H160, H256};
 use sp_std::prelude::*;
 
-use alloy_primitives::B256;
-use alloy_sol_types::{sol, SolEvent};
+use alloy_core::primitives::B256;
+use alloy_core::sol;
+use alloy_core::sol_types::{SolEvent};
 
 sol! {
 	event OutboundMessageAccepted(bytes32 indexed channel_id, uint64 nonce, bytes32 indexed message_id, bytes payload);

--- a/bridges/snowbridge/primitives/inbound-queue/src/v1.rs
+++ b/bridges/snowbridge/primitives/inbound-queue/src/v1.rs
@@ -13,8 +13,9 @@ use sp_core::{Get, RuntimeDebug, H160, H256};
 use sp_runtime::{traits::MaybeEquivalence, DispatchError, MultiAddress};
 use sp_std::prelude::*;
 use xcm::prelude::{Junction::AccountKey20, *};
-use alloy_primitives::B256;
-use alloy_sol_types::{sol, SolEvent};
+use alloy_core::primitives::B256;
+use alloy_core::sol;
+use alloy_core::sol_types::SolEvent;
 
 const MINIMUM_DEPOSIT: u128 = 1;
 


### PR DESCRIPTION
In tanssi-polkadot-stable2503 we use explicit dependencies to old versions of "alloy-primitives" and "alloy-sol-types". These are replaced by imports from "alloy-core" in upstream stable2503.

https://github.com/paritytech/polkadot-sdk/blob/913bb8b588aeef4daa63c73ea13ee1f3ecd5b5b5/bridges/snowbridge/primitives/inbound-queue/Cargo.toml#L18

https://github.com/paritytech/polkadot-sdk/blob/913bb8b588aeef4daa63c73ea13ee1f3ecd5b5b5/bridges/snowbridge/primitives/inbound-queue/src/v2/message.rs#L9

The main issue is that alloy-primitives 0.4 depends on primitive-types 0.12, which can cause problems with the rest of the codebase that needs primitive-types 0.13