### PR TITLE
Increase `max_upward_message_size` in `RelayStateSproofBuilder` to allow for larger XCM messages during testing.

### DIFF
--- a/prdoc/pr_15.prdoc
+++ b/prdoc/pr_15.prdoc
@@ -1,0 +1,16 @@
+title: Increase `max_upward_message_size` in `RelayStateSproofBuilder`
+doc:
+  audience: Runtime Dev
+  description: |-
+    ## Description
+
+    While testing different XCM messages via xcm-emulator, I noticed that the
+    limit of 256 for `max_upward_message_size` in `RelayStateSproofBuilder` can
+    be reached very easily.
+
+    I suggest increasing it to `1024 * 1024` so that we can have a good range
+    for testing.
+crates:
+- name: xcm-emulator
+  bump: patch
+p


### PR DESCRIPTION
Description

Increase the max_upward_message_size in RelayStateSproofBuilder from 256 to 1,048,576 to allow larger XCM messages during testing.
This change ensures that tests using the xcm-emulator can handle bigger messages without hitting the previous limit.

Integration

No special integration required. This is a runtime testing change and does not affect production behavior. Downstream projects can continue using RelayStateSproofBuilder as before; only test scenarios with large XCM messages will benefit.

Review Notes

Implementation is a simple increase of the constant max_upward_message_size.

No new dependencies introduced.

Example test scenario: sending an upward XCM message exceeding 256 bytes in xcm-emulator now passes.

No leftover TODOs; change is self-contained.

Checklist

 My PR includes a detailed description as outlined in the "Description" and its two subsections above.

 My PR follows the labeling requirements (ask maintainers to add the appropriate label if necessary).

 Documentation updated if applicable (not required for this testing change).

 Tests added or updated to verify the increased max_upward_message_size.