### PR TITLE
modify message processor trait to return worst case weight + refund excess weight

### DIFF
--- a/bridges/snowbridge/pallets/inbound-queue-v2/src/lib.rs
+++ b/bridges/snowbridge/pallets/inbound-queue-v2/src/lib.rs
@@ -38,6 +38,7 @@ mod test;
 pub use crate::weights::WeightInfo;
 use bp_relayers::RewardLedger;
 use frame_system::ensure_signed;
+use frame_support::dispatch::PostDispatchInfo;
 use snowbridge_core::{
 	reward::{AddTip, AddTipError},
 	sparse_bitmap::{SparseBitmap, SparseBitmapImpl},
@@ -180,8 +181,8 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Submit an inbound message originating from the Gateway contract on Ethereum
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::submit())]
-		pub fn submit(origin: OriginFor<T>, event: Box<EventProof>) -> DispatchResult {
+		#[pallet::weight(T::WeightInfo::submit().saturating_add(T::MessageProcessor::worst_case_message_processor_weight()))]
+		pub fn submit(origin: OriginFor<T>, event: Box<EventProof>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			ensure!(!OperatingMode::<T>::get().is_halted(), Error::<T>::Halted);
 
@@ -211,7 +212,7 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		pub fn process_message(relayer: T::AccountId, message: Message) -> DispatchResult {
+		pub fn process_message(relayer: T::AccountId, message: Message) -> DispatchResultWithPostInfo {
 			// Verify that the message was submitted from the known Gateway contract
 			ensure!(T::GatewayAddress::get() == message.gateway, Error::<T>::InvalidGateway);
 
@@ -223,7 +224,7 @@ pub mod pallet {
 			// Mark message as received
 			Nonce::<T>::set(nonce);
 
-			let message_id = T::MessageProcessor::process_message(relayer.clone(), message)
+			let (message_id, maybe_corrected_weight) = T::MessageProcessor::process_message(relayer.clone(), message)
 				.map_err(|e| match e {
 					MessageProcessorError::ProcessMessage(e) => e,
 					MessageProcessorError::ConvertMessage(e) => Error::<T>::from(e).into(),
@@ -240,7 +241,16 @@ pub mod pallet {
 			// Emit event with the message_id
 			Self::deposit_event(Event::MessageReceived { nonce, message_id });
 
-			Ok(())
+			if let Some(corrected_weight) = maybe_corrected_weight {
+				Ok(PostDispatchInfo {
+					actual_weight: Some(corrected_weight.saturating_add(T::WeightInfo::submit())),
+					..Default::default()
+				})
+			}
+			else {
+				// Pays fees and non-corrected-weight
+				Ok(().into())
+			}
 		}
 	}
 

--- a/bridges/snowbridge/primitives/inbound-queue/src/v2/processor.rs
+++ b/bridges/snowbridge/primitives/inbound-queue/src/v2/processor.rs
@@ -33,10 +33,10 @@ where
 	fn process_message(
 		relayer: AccountId,
 		message: Message,
-	) -> Result<[u8; 32], MessageProcessorError> {
+	) -> Result<([u8; 32], Option<Weight>), MessageProcessorError> {
 		// Process the message and return its ID
 		let id = Self::process_xcm(relayer, message)?;
-		Ok(id)
+		Ok((id, None))
 	}
 }
 

--- a/bridges/snowbridge/primitives/inbound-queue/src/v2/traits.rs
+++ b/bridges/snowbridge/primitives/inbound-queue/src/v2/traits.rs
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: 2021-2025 Parity Technologies (UK) Ltd.
 use super::Message;
 use sp_core::RuntimeDebug;
-use sp_runtime::DispatchError;
+use sp_runtime::{DispatchError, Weight};
 use xcm::latest::{SendError, Xcm};
 
 /// Converts an inbound message from Ethereum to an XCM message that can be
@@ -42,7 +42,12 @@ pub trait MessageProcessor<AccountId> {
 	fn process_message(
 		relayer: AccountId,
 		message: Message,
-	) -> Result<[u8; 32], MessageProcessorError>;
+	) -> Result<([u8; 32], Option<Weight>), MessageProcessorError>;
+
+	/// Returns the worst case message processor weight
+	fn worst_case_message_processor_weight() -> Weight {
+		Weight::default()
+	}
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(10)]
@@ -63,7 +68,7 @@ impl<AccountId> MessageProcessor<AccountId> for Tuple {
 	fn process_message(
 		relayer: AccountId,
 		message: Message,
-	) -> Result<[u8; 32], MessageProcessorError> {
+	) -> Result<([u8; 32], Option<Weight>), MessageProcessorError> {
 		for_tuples!( #(
  			match Tuple::can_process_message(&relayer, &message) {
 				true => {
@@ -76,5 +81,17 @@ impl<AccountId> MessageProcessor<AccountId> for Tuple {
 		Err(MessageProcessorError::ProcessMessage(DispatchError::Other(
 			"No handler found for message!",
 		)))
+	}
+
+	fn worst_case_message_processor_weight() -> Weight {
+		let mut max_weight = Weight::zero();
+
+		for_tuples!( #(
+			max_weight = max_weight.max(
+				Tuple::worst_case_message_processor_weight()
+			);
+		)* );
+
+		max_weight
 	}
 }


### PR DESCRIPTION
# Description
Cherry-pick of https://github.com/paritytech/polkadot-sdk/pull/10688

It modifies message processor trait to return worst case weight, plus modifes `process_message` to return correct weight so that we can refund excess weight.